### PR TITLE
Add test of photometry predictions for galaxy population

### DIFF
--- a/janet/magpred.py
+++ b/janet/magpred.py
@@ -2,6 +2,7 @@
 """
 from jax import jit as jjit
 from jax import numpy as jnp
+from jax import vmap
 from .flux import _calc_rest_mag_multifilter
 from .wssp import _calc_weighted_ssp_from_diffstar_params
 from .stars import DEFAULT_MAH_PARAMS
@@ -39,3 +40,7 @@ def _pred_mags_singlegal(
 
     mags = _calc_rest_mag_multifilter(ssp_wave, lum_spec, wave_filters, trans_filters)
     return mags
+
+
+_a = [0, *[None] * 7]
+_pred_mags_galpop = jjit(vmap(_pred_mags_singlegal, in_axes=_a))

--- a/janet/tests/test_magpred.py
+++ b/janet/tests/test_magpred.py
@@ -56,7 +56,7 @@ def test_calc_weighted_ssp_from_diffstarpop():
     q_params = np.array(list(DEFAULT_Q_PARAMS.values()))
     params_singlegal = np.array((*mah_params, *ms_params, *q_params))
 
-    n_gals = 10_000
+    n_gals = 1_000
     shape_pop = (n_gals, params_singlegal.size)
     params_galpop = np.tile(params_singlegal, n_gals).reshape(shape_pop)
 

--- a/janet/tests/test_magpred.py
+++ b/janet/tests/test_magpred.py
@@ -2,7 +2,7 @@
 """
 import numpy as np
 from ..stars import DEFAULT_MS_PARAMS, DEFAULT_Q_PARAMS
-from ..magpred import _pred_mags_singlegal
+from ..magpred import _pred_mags_singlegal, _pred_mags_galpop
 from ..stars import DEFAULT_MAH_PARAMS as MAH_PARS
 
 
@@ -41,3 +41,44 @@ def test_calc_weighted_ssp_from_diffstar_params():
     )
     mags_pred = _pred_mags_singlegal(*args)
     assert mags_pred.shape == (n_filters,)
+
+
+def test_calc_weighted_ssp_from_diffstarpop():
+
+    t_obs = 11.0
+    n_met, n_age, n_wave_spec = 22, 94, 1_000
+    lg_ages = np.linspace(6, 10, n_age) - 9
+    ssp_templates = np.zeros((n_met, n_age, n_wave_spec))
+    lgZsun_bin_mids = np.linspace(-2, 0, n_met)
+
+    mah_params = np.array(list(MAH_PARS.values()))
+    ms_params = np.array(list(DEFAULT_MS_PARAMS.values()))
+    q_params = np.array(list(DEFAULT_Q_PARAMS.values()))
+    params_singlegal = np.array((*mah_params, *ms_params, *q_params))
+
+    n_gals = 10_000
+    shape_pop = (n_gals, params_singlegal.size)
+    params_galpop = np.tile(params_singlegal, n_gals).reshape(shape_pop)
+
+    n_wave_filter = 300
+    wave_filter = np.linspace(0, 1, n_wave_filter)
+    trans_filter = np.ones_like(wave_filter)
+
+    ssp_wave = np.linspace(0, 1, n_wave_spec)
+
+    n_filters = 6
+    waves_filters = np.tile(wave_filter, n_filters).reshape((n_filters, -1))
+    trans_filters = np.tile(trans_filter, n_filters).reshape((n_filters, -1))
+
+    args = (
+        params_galpop,
+        t_obs,
+        waves_filters,
+        trans_filters,
+        ssp_wave,
+        ssp_templates,
+        lgZsun_bin_mids,
+        lg_ages,
+    )
+    mags_pred = _pred_mags_galpop(*args)
+    assert mags_pred.shape == (n_gals, n_filters)


### PR DESCRIPTION
PR brings in memory-intensive unit test of a prediction for the photometry of a galaxy population using jax.vmap